### PR TITLE
Create release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,29 @@
+name: create_release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get version
+        id: version
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'manifest.json'
+          prop_path: 'version'
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          body: "Changelog: https://github.com/${{ github.repository }}/commits/${{ steps.version.outputs.prop }}"
+          tag: ${{ steps.version.outputs.prop }}
+          token: ${{ secrets.BROWSER_EXTENSION_TOKEN }}
+          allowUpdates: true
+          replacesArtifacts: true

--- a/.github/workflows/upload_extension.yml
+++ b/.github/workflows/upload_extension.yml
@@ -1,0 +1,27 @@
+# name: upload_extension
+
+# on:
+#   release:
+#     types: [released]
+
+# jobs:
+#   upload_extension:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Download release
+#         uses: robinraju/release-downloader@v1.7
+#         with:
+#           tag: ${{ github.event.release.tag_name }}
+#           out-file-path: "./"
+#           zipBall: true
+#       - name: Rename
+#         run: |
+#           mv *.zip result.zip
+#       - name: Upload extension to Chrome Web Store
+#         uses: mnao305/chrome-extension-upload@v4.0.0
+#         with:
+#           file-path: ./result.zip
+#           extension-id: ${{ secrets.EXTENSION_ID }}
+#           client-id: ${{ secrets.CHROME_API_CLIENT_ID }}
+#           client-secret: ${{ secrets.CHROME_API_CLIENT_SECRET }}
+#           refresh-token: ${{ secrets.CHROME_API_REFRESH_TOKEN }}


### PR DESCRIPTION
Create a new release based on version in `manifest.json` file
If version isn't changed, it just updates the release, but it doesn't updates the zip file

Upload extension to chrome web store will be tested later